### PR TITLE
Windows-compatible build

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Zepto.js and **npm-zepto** are licensed under the terms of the MIT License.
 $ npm install npm-zepto
 ```
 
-## Windows
-Shown to work on Windows 10 by installing Git for Windows and running from Git Bash.
-
 Then you can include it using CommonJS as you pleased.
 
 ```javascript
 var zepto = require('npm-zepto');
 ```
+
+## Windows
+Shown to work on Windows 10 by installing Git for Windows and running from Git Bash.
 
 > We have desided compiling **npm-zepto** as a CommonJS type library instead a UMD.
 > Nonetheless if you need a AMD library you can clone the repo an run the amd_build script in order to buil a RequiredJS compatible Zepto library.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Zepto.js and **npm-zepto** are licensed under the terms of the MIT License.
 $ npm install npm-zepto
 ```
 
+## Windows
+Shown to work on Windows 10 by installing Git for Windows and running from Git Bash.
+
 Then you can include it using CommonJS as you pleased.
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "install": "script/build"
+    "install": "script/build || sh script/build"
   },
   "repository": {
     "type": "git",

--- a/script/build
+++ b/script/build
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
 
+git submodule update --init
 cd zepto
 npm install
 npm run-script dist


### PR DESCRIPTION
I was unable to `npm i` on Windows 10 without a small change, so I'm pushing the change back to you.